### PR TITLE
example of the 2-separate-fetch-problem when multiple childs exists and those are joined

### DIFF
--- a/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/fetching/pagination/PaginationTest.java
+++ b/core/src/test/java/com/vladmihalcea/book/hpjp/hibernate/fetching/pagination/PaginationTest.java
@@ -184,13 +184,16 @@ public class PaginationTest extends AbstractTest {
     public void testFetchAndPaginateWithTwoQueries() {
         doInJPA(entityManager -> {
             List<Long> postIds = entityManager
-            .createQuery(
-                "select p.id " +
+            .createNativeQuery(
+                "select distinct(t.id) from (p.id " +
                 "from Post p " +
-                "where p.title like :titlePattern " +
-                "order by p.createdOn", Long.class)
-            .setParameter("titlePattern", "High-Performance Java Persistence %")
-            .setMaxResults(5)
+                "join PostComment pc " +                
+                "on p.id = pc.post_id " +                                
+                "where pc.review like :review " +
+                "order by pc.review offset :offSet rows fetch next :limit rows only) t", Long.class)
+            .setParameter("review", "Great%")
+            .setParameter("offSet", 0)
+            .setParameter("limit", 5)                                    
             .getResultList();
 
             List<Post> posts = entityManager.createQuery(


### PR DESCRIPTION
example of the 2-separate-fetch-problem when multiple childs exists and those are joined; With select distinct(t.id) we may get less IDs than the limited size (distinct should kind-of happen inside the subquery but thats not possible if we want to order-by by postComment.review for example). If we omit the distinct keyword we may get same Post.ID multiple times(thus later query would have 4 ids passed in as parameter for example when 5 'expected')